### PR TITLE
Allow ogmios v7 in version validation

### DIFF
--- a/bootstrap/instance/main.tf
+++ b/bootstrap/instance/main.tf
@@ -6,8 +6,8 @@ variable "ogmios_version" {
   type = string
 
   validation {
-    condition     = contains(["5", "6"], var.ogmios_version)
-    error_message = "Invalid version. Allowed values are 5 or 6."
+    condition     = contains(["5", "6", "7"], var.ogmios_version)
+    error_message = "Invalid version. Allowed values are 5, 6 or 7."
   }
 }
 

--- a/bootstrap/service/main.tf
+++ b/bootstrap/service/main.tf
@@ -10,7 +10,7 @@ variable "ogmios_version" {
   type = string
 
   validation {
-    condition     = contains(["5", "6"], var.ogmios_version)
-    error_message = "Invalid version. Allowed values are 5 or 6."
+    condition     = contains(["5", "6", "7"], var.ogmios_version)
+    error_message = "Invalid version. Allowed values are 5, 6 or 7."
   }
 }


### PR DESCRIPTION
## Summary
The bootstrap module's `ogmios_version` validation hard-restricts to `{5, 6}`, so any instance declared with `ogmios_version = "7"` fails at plan time:

```
Error: Invalid value for variable — var.ogmios_version is "7"
  Invalid version. Allowed values are 5 or 6.
  at bootstrap/instance/main.tf (validation rule)
```

PR #88 added the `docker/ogmios-7` image (`cardanosolutions/ogmios:v7.0.0`) and CI, but not the terraform support. This extends the version validation to accept `"7"` in both places that gate it:

- `bootstrap/instance/main.tf` — the instance Deployment (blocks a v7 instance).
- `bootstrap/service/main.tf` — the well-known upstream Service (hit once `"7"` is added to a deployment's `versions`).

No other module logic needs changing: the container args at `bootstrap/instance/ogmios.tf` already treat any non-v5 version as `--include-cbor`, which is correct for v7.

## Downstream
Once merged, cluster configs pinning the module `ref` can bump to this SHA to deploy v7 instances (e.g. the `m2-prod-7xjh33` preprod v7 validation instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)