### PR TITLE
Restore ogmios CLI args on instance container

### DIFF
--- a/bootstrap/instance/ogmios.tf
+++ b/bootstrap/instance/ogmios.tf
@@ -138,6 +138,7 @@ resource "kubernetes_deployment_v1" "ogmios" {
           name              = "main"
           image             = local.image
           image_pull_policy = "IfNotPresent"
+          args              = local.container_args
 
           env {
             name  = "NETWORK"


### PR DESCRIPTION
## Summary
`ce37a59` replaced the ogmios CLI args (`--node-socket /ipc/node.socket`, `--node-config /config/config.json`, `--host 0.0.0.0`, `--include-cbor`) with a `NETWORK` env var to match the **Blink Labs** ogmios image entrypoint. That image was a **temporary** solution.

The permanent images are the `cardanosolutions`-based `ext-cardano-ogmios-instance-*` builds (see `docker/ogmios-5|6|7`), whose entrypoint is the raw `ogmios` binary and **requires** those args to reach the socat-tunneled node socket. Without them the container can't connect and won't sync.

This restores `args = local.container_args` on the instance container (the local is still defined) while leaving the `NETWORK` env var in place, so the still-running temporary Blink Labs pods aren't disturbed during the transition.

## Why now
Needed to deploy **v7** instances (which use the cardanosolutions-based `ext-cardano-ogmios-instance-7` image, #88). With the current `main`, a v7 instance would come up with no args and fail to connect.

## Downstream
Clusters can bump the module `ref` to this commit to deploy v7 with the args model (e.g. the `m2-prod-7xjh33` preprod v7 validation instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)