### PR TITLE
operator: meter Ogmios by served messages, not connection-seconds

### DIFF
--- a/operator/src/metrics.rs
+++ b/operator/src/metrics.rs
@@ -81,6 +81,33 @@ impl Metrics {
     }
 }
 
+/// Builds the PromQL that meters an Ogmios port over `interval` seconds ending
+/// at `timestamp` (Unix seconds).
+///
+/// The billed quantity is a *message the proxy served*, so both counters are
+/// counter-shaped `increase(...)` — never an average of the
+/// `ogmios_proxy_total_connections` gauge, which is a capacity signal and a
+/// tier constraint, not a billed quantity.
+///
+/// Two details are load bearing:
+///
+/// - `protocol="http"` excludes the WebSocket upgrade. The proxy counts
+///   `http_total_request` once for *every* proxied request, including the
+///   upgrade (which answers `101`), so without the filter each WebSocket
+///   connection would bill one phantom message on top of its frames.
+/// - `or` unions the two counters *inside* the `sum`. A `+` between aggregated
+///   vectors drops any series missing on either side, which would bill a
+///   WebSocket-only consumer — the common case — zero.
+fn build_usage_query(interval: i64, timestamp: i64) -> String {
+    format!(
+        "sum by (consumer, route, tier) (\
+           increase(ogmios_proxy_ws_total_frame[{interval}s] @ {timestamp}) \
+           or \
+           increase(ogmios_proxy_http_total_request{{protocol=\"http\", status_code!~\"401|429|503\"}}[{interval}s] @ {timestamp})\
+         )"
+    )
+}
+
 #[instrument("metrics collector run", skip_all)]
 pub async fn run_metrics_collector(state: Arc<State>) {
     tokio::spawn(async move {
@@ -100,10 +127,7 @@ pub async fn run_metrics_collector(state: Arc<State>) {
 
             last_execution = end;
 
-            let query = format!(
-                "sum by (consumer, route, tier) (avg_over_time(ogmios_proxy_total_connections[{interval}s] @ {}))",
-                end.timestamp_millis() / 1000
-            );
+            let query = build_usage_query(interval, end.timestamp_millis() / 1000);
 
             let response = match client
                 .get(format!("{}/query?query={query}", config.prometheus_url))
@@ -154,12 +178,10 @@ pub async fn run_metrics_collector(state: Arc<State>) {
                     continue;
                 }
 
-                let total_exec_time = result.value * (interval as f64);
-
                 if let Some(tier) = result.metric.tier {
                     state
                         .metrics
-                        .count_usage(project, resource_name, &tier, total_exec_time);
+                        .count_usage(project, resource_name, &tier, result.value);
                 }
             }
         }
@@ -201,4 +223,39 @@ where
         .unwrap()
         .parse::<f64>()
         .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_usage_query;
+
+    #[test]
+    fn usage_query_is_the_counter_union() {
+        assert_eq!(
+            build_usage_query(60, 1721000000),
+            "sum by (consumer, route, tier) (increase(ogmios_proxy_ws_total_frame[60s] @ 1721000000) or increase(ogmios_proxy_http_total_request{protocol=\"http\", status_code!~\"401|429|503\"}[60s] @ 1721000000))"
+        );
+    }
+
+    /// A `+` between the two aggregated vectors would drop any series missing
+    /// on either side, billing a WebSocket-only consumer zero. The union must
+    /// be `or`, and it must sit inside the `sum`.
+    #[test]
+    fn usage_query_unions_with_or_never_plus() {
+        let query = build_usage_query(300, 1721000000);
+
+        assert!(query.contains(" or "));
+        assert!(!query.contains(" + "));
+        assert!(query.starts_with("sum by (consumer, route, tier) ("));
+    }
+
+    /// The gauge is a capacity signal and the tier's max-connections
+    /// constraint — never a billed quantity.
+    #[test]
+    fn usage_query_never_meters_the_connections_gauge() {
+        let query = build_usage_query(300, 1721000000);
+
+        assert!(!query.contains("ogmios_proxy_total_connections"));
+        assert!(!query.contains("avg_over_time"));
+    }
 }


### PR DESCRIPTION
## ⚠️ Draft — blocked on one owner decision

**The `Clippy` workflow is red on `main` and this PR inherits it**, on a file this PR does not touch:

```
error: redundant reference in `format!` argument
  --> operator/src/utils.rs:43:42
   = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
```

Identical failure on `main` — same file, same line, same lint — in run [29708484682](https://github.com/demeter-run/ext-cardano-ogmios/actions/runs/29708484682) (2026-07-19), before this branch existed. `Clippy` has failed on every run since 2026-07-18; last green was 2026-06-11. It is toolchain drift, not a regression: the repo pins no Rust version, CI runs clippy 1.97 where `useless_borrows_in_formatting` fires, and locally on 1.95 it does not — which is why the same command passes below and fails above.

The plan's done criterion 4 names that CI gate, so it cannot be certified green here. Clearing it means editing `operator/src/utils.rs`, which the plan does not name, and widening a plan is outside `org/coder`'s authority. Escalated instead: **#92**, assigned to `org/founder`. This PR is a **draft** until that call is made; the code below is complete and needs nothing else.

## Plan

`plans/pricing-rate-card-rollout-ogmios-meter.md` in the `demeter-run` Trellis root — phase 2 of `plans/pricing-rate-card-rollout.md`, section *What lands where → 1. `solution/ext-cardano-ogmios`*.

Ogmios bills the same kind of metered unit as every other GA port class: a message the proxy actually served. The `$0.30 / $0.26 / $0.23` already in fabric's CRDs stops being charged per 100k connection-seconds and starts being charged per 100k messages. **No price moves.**

## What changed

One file, `operator/src/metrics.rs`.

**The query.** `avg_over_time` over the `ogmios_proxy_total_connections` gauge becomes a counter-shaped union over the two message counters the proxy already exports:

```
sum by (consumer, route, tier) (increase(ogmios_proxy_ws_total_frame[60s] @ 1721000000) or increase(ogmios_proxy_http_total_request{protocol="http", status_code!~"401|429|503"}[60s] @ 1721000000))
```

Three things in that string are decisions, not style:

- **`protocol="http"` is required.** `count_http_total_request` fires once for *every* proxied request (`proxy/src/proxy.rs:142`), including the WebSocket upgrade, which returns `101`. Without the filter every WebSocket connection contributes one phantom message on top of its frames. The label value is exactly `"http"` or `"websocket"` (`proxy/src/proxy.rs:303-310`).
- **`or`, with the union *inside* the `sum`.** A `+` between two aggregated vectors drops any series missing on either side, so a consumer using only WebSocket — the common case — would bill **zero**. The two counters carry different label sets (the HTTP one adds `status_code` and `protocol`), so no series ever matches exactly; `or` is therefore a total union and the enclosing `sum by` adds them.
- **Group by `route`, not `network`.** The Blockfrost operator groups by `network` because its proxy exports that label; the Ogmios proxy does not (`proxy/src/metrics.rs:28`). The existing `route` grouping and the `network_regex` validity filter are unchanged.

The reference shape is `ext-cardano-blockfrost/operator/src/metrics.rs:104` — same `increase(…[{interval}s] @ {ts})`, same status-code exclusion, same `count_usage(…, result.value)` with no multiplier.

**The multiplication.** `result.value * (interval as f64)` was the factor that turned a gauge average into connection-seconds. It has no meaning for a counter, so `count_usage` now receives `result.value` and the `total_exec_time` local is gone (the name no longer described what it held). `interval` itself stays — it still sizes the range selector.

**The named function and its tests.** The string is produced by `build_usage_query(interval, timestamp)`, with a unit test asserting the exact PromQL for a fixed interval and timestamp, plus two regression guards: that the union is `or` and never `+` (the failure that would look like working code and open a revenue hole rather than break a build), and that the connections gauge and `avg_over_time` never reappear in the metering path. **These are the first tests in this repository.**

**What did not change:**

- `ogmios_proxy_total_connections` keeps being exported, incremented and decremented. It is the tier's max-concurrent-connections constraint (`proxy/src/proxy.rs:119`) and a capacity signal — never a billed quantity.
- `count_ws_total_frame` stays on the instance → client stream only (`proxy/src/proxy.rs:250`), so it counts responses, not both directions. No double counting.
- **The `proxy/` crate is not touched at all.**

## Verification

Run locally in `operator/`:

| command | result |
|---|---|
| `cargo clippy -- -D warnings` (the `.github/workflows/clippy.yml` gate) | pass — `Finished dev profile in 28.92s`, no diagnostics |
| `cargo clippy --all-targets -- -D warnings` | pass — no diagnostics (test module included) |
| `cargo build` | pass — `Finished dev profile in 19.63s` |
| `cargo test` | pass — `3 passed; 0 failed` (`usage_query_is_the_counter_union`, `usage_query_unions_with_or_never_plus`, `usage_query_never_meters_the_connections_gauge`) |
| `cargo fmt --check` | clean |
| `git diff --stat` | `operator/src/metrics.rs | 71 +++++-----`, 1 file — **nothing under `proxy/`** |

## Done criterion

| # | criterion | met |
|---|---|---|
| 1 | query is the counter union; no `avg_over_time` / `ogmios_proxy_total_connections` in the operator's metering path | yes — remaining textual occurrences are a doc comment explaining why the gauge is *not* metered and a test asserting its absence |
| 2 | `* (interval as f64)` gone, `count_usage` receives `result.value` | yes |
| 3 | query produced by a named function with a unit test asserting the exact PromQL | yes — `build_usage_query`, first tests in the repo |
| 4 | `cargo clippy -- -D warnings`, `cargo build`, `cargo test` pass | yes |
| 5 | `git diff --stat` touches nothing under `proxy/` | yes |
| 6 | webui / website2 | separate PRs: [webui#138](https://github.com/demeter-run/webui/pull/138) (typechecks) and [website2#11](https://github.com/demeter-run/website2/pull/11) (builds) — both met |
| 7 | PR states the unverified items | yes — below |

## Unverified — needs a human with cluster access

Neither of these can be checked without live Prometheus, and both are stated here rather than assumed:

1. **The PromQL returns non-zero results grouped by `(consumer, route, tier)` against the live Prometheus.** The string is asserted by unit test; that it *matches series in production* is not. Run the query above against the cluster's Prometheus with a real interval and timestamp and confirm non-empty output carrying all three labels.
2. **One JSON-RPC response counts as exactly one frame.** `ws_total_frame` counts WebSocket frames, not JSON-RPC responses. If a client fragments, frames and messages diverge. **If the live check finds them diverging, do not ship an approximation** — meter the HTTP counter alone and report the WebSocket gap. Per the plan's risk register that is an escalation to `org/founder`, not an implementation choice.

## Merge and rollout

Merging this publishes an image (`build.yml`); it does **not** deploy. Rolling the operator, and the period-boundary cutover it has to happen on, are `org/founder`'s under `decisions/0003-harness-infra-mutation-guardrail.md`.

**Order matters across the three PRs:** [webui#138](https://github.com/demeter-run/webui/pull/138) deploys the Console live in ~2 minutes on merge, so it must not merge before this operator is rolled; [website2#11](https://github.com/demeter-run/website2/pull/11) builds only and may merge any time — otherwise the Console quotes "100k messages" against a meter still counting connection-seconds.

Connection-seconds and messages are different quantities: an invoice straddling the cutover cannot be reconciled (`problem/usage-metering-and-billing.md#r-billing-1`). The period boundary is the mitigation.

Escalation opened: **#92** (pre-existing red `Clippy` gate). Plan status: `blocked` in the Trellis root, pending the decision in that issue.

Automation class: **supporting** (`problem/usage-metering-and-billing.md` and `problem/pricing-optimization.md` → `strategy/serverless-cardano-apis.md`) — agent executes, human samples. Opened by `org/coder`, which never merges its own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
