### PR TITLE
feat(instance): enable --metadata-detailed-schema on ogmios v7

### DIFF
--- a/bootstrap/instance/ogmios.tf
+++ b/bootstrap/instance/ogmios.tf
@@ -7,7 +7,11 @@ locals {
     "--node-config", "/config/config.json",
     "--host", "0.0.0.0"
   ]
-  container_args = var.ogmios_version == "5" ? local.default_args : concat(local.default_args, ["--include-cbor"])
+  container_args = var.ogmios_version == "5" ? local.default_args : concat(
+    local.default_args,
+    ["--include-cbor"],
+    var.ogmios_version == "7" ? ["--metadata-detailed-schema"] : []
+  )
 }
 
 resource "kubernetes_deployment_v1" "ogmios" {


### PR DESCRIPTION
## What

Adds `--metadata-detailed-schema` to the ogmios instance container args, **gated on version 7 only**.

```hcl
container_args = var.ogmios_version == "5" ? local.default_args : concat(
  local.default_args,
  ["--include-cbor"],
  var.ogmios_version == "7" ? ["--metadata-detailed-schema"] : []
)
```

## Why here

Ogmios renders transaction metadata with the no-schema JSON encoding by default. The detailed schema is a **startup-only server flag** — there is no per-request or per-connection override ([`Options.hs`](https://github.com/CardanoSolutions/ogmios/blob/master/server/src/Ogmios/Options.hs)), so it has to be set on the instance container. This is the only place instance args are rendered.

## Why v7 only

Version is already the routing key — the proxy resolves `ogmios-<network>-<version>` (`proxy/src/config.rs:72`) and `OgmiosPortSpec` carries `version`. So "v7 means detailed schema" is expressible with **no new port dimension**: no CRD change, no operator change, no proxy change, no console/catalog change.

Confirmed present in the `v7.0.0` tag of `Options.hs`.

## Blast radius

`terraform console` on the extracted expression — v5 and v6 render **byte-identical** to today:

| version | args |
|---|---|
| 5 | `--node-socket … --node-config … --host 0.0.0.0` (unchanged) |
| 6 | `… --include-cbor` (unchanged) |
| 7 | `… --include-cbor --metadata-detailed-schema` |

So only the three v7 deployments diff. Existing v6 consumers keep the metadata shape they parse today.

## Rollout

Targeted apply on `m2-prod-7xjh33` stage4, v7 instances only:

```
-target='module.ext_ogmios_m1.module.ogmios_instances["mainnet-7-m7a"]'
-target='module.ext_ogmios_m1.module.ogmios_instances["preprod-7-p7a"]'
-target='module.ext_ogmios_m1.module.ogmios_instances["preview-7-w7a"]'
```

Targeting is required — an untargeted apply reverts two documented drifts in that file (proxy-green replicas, blinklabs v6 images).

## Note

`--include-cbor` implies `--include-metadata-cbor`, so each metadatum will now carry **both** the CBOR hex and the detailed JSON. If the redundancy is unwanted, swap the shorthand for `--include-transaction-cbor --include-script-cbor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)